### PR TITLE
[BUGFIX] Widgets get 0 hieght and 0 width

### DIFF
--- a/app/components/widget.js
+++ b/app/components/widget.js
@@ -45,6 +45,9 @@ export default class WidgetComponent extends Component {
       let contentRect = entries[0].contentRect;
       let width = contentRect.width;
       let height = contentRect.height;
+      if (width === 0 && height === 0) {
+        return;
+      }
       this.args.onResize(width, height);
       clearTimeout(this.resizeEvent);
       this.resizeEvent = setTimeout(() => {

--- a/app/routes/dashboard.js
+++ b/app/routes/dashboard.js
@@ -1,3 +1,9 @@
 import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+export default class DashboardRoute extends Route {
+  @service store;
 
-export default class DashboardRoute extends Route {}
+  model(params) {
+    return this.store.find('dashboard', params.dashboard_id);
+  }
+}


### PR DESCRIPTION
This was caused because when the resize observer gets fired for the
first time the width and the height are 0, then the save events are
fired.

fixes https://github.com/billybonks/radar/issues/41