### PR TITLE
bugfix: charts doesnt display in quickinput

### DIFF
--- a/app/instance-initializers/bump-charts.js
+++ b/app/instance-initializers/bump-charts.js
@@ -1,0 +1,10 @@
+// hack to fix https://github.com/billybonks/radar/issues/36
+
+export function initialize(appInstance) {
+  let store = appInstance.lookup('service:store');
+  store.findAll('chart')
+}
+
+export default {
+  initialize,
+};


### PR DESCRIPTION
ON first render the charts don't display not sure why but works for
dashboards. in the mean time we can preload charts until we dig deeper.

https://github.com/billybonks/radar/issues/36